### PR TITLE
Add test documentation for Claude Code review

### DIFF
--- a/.github/workflows/debug-api-connection.yml
+++ b/.github/workflows/debug-api-connection.yml
@@ -1,0 +1,59 @@
+name: Debug API Connection
+
+on:
+  workflow_dispatch:  # Manual trigger for testing
+
+jobs:
+  debug-connection:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Test Network Connectivity
+        run: |
+          echo "Testing network connectivity to Anthropic API..."
+          
+          # Test basic connectivity
+          echo "=== DNS Resolution ==="
+          nslookup api.anthropic.com || echo "DNS resolution failed"
+          
+          echo "=== Ping Test ==="
+          ping -c 3 api.anthropic.com || echo "Ping failed"
+          
+          echo "=== HTTP Connectivity ==="
+          curl -v -H "Content-Type: application/json" \
+               -H "x-api-key: test-key" \
+               --connect-timeout 10 \
+               --max-time 30 \
+               https://api.anthropic.com/v1/messages || echo "HTTP connection failed"
+          
+          echo "=== Environment Info ==="
+          echo "Runner IP:"
+          curl -s https://httpbin.org/ip || echo "IP detection failed"
+          
+          echo "=== DNS Servers ==="
+          cat /etc/resolv.conf
+          
+      - name: Test API Key Format
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          echo "=== API Key Check ==="
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "❌ ANTHROPIC_API_KEY is empty or not set"
+            exit 1
+          fi
+          
+          echo "✅ API key is set"
+          echo "Key length: ${#ANTHROPIC_API_KEY}"
+          echo "Key prefix: ${ANTHROPIC_API_KEY:0:12}..."
+          
+          # Check for common formatting issues
+          if [[ "$ANTHROPIC_API_KEY" =~ [[:space:]] ]]; then
+            echo "⚠️  API key contains whitespace"
+          fi
+          
+          if [[ "$ANTHROPIC_API_KEY" == sk-ant-api-* ]]; then
+            echo "✅ API key has correct format"
+          else
+            echo "⚠️  API key doesn't start with expected prefix"
+          fi

--- a/docs/test-claude-review.md
+++ b/docs/test-claude-review.md
@@ -1,0 +1,44 @@
+# Test Documentation
+
+This documentation will be reviewed by the automated system to verify that Claude Code integration is working properly.
+
+## Installation
+
+The software should be installed by the user. In order to install the software, the following steps will need to be completed by the administrator:
+
+- The package should be downloaded from the repository
+- Installation should be performed by the system
+- Configuration files should be updated appropriately  
+- The service should be restarted
+
+Due to the fact that security is important, one should ensure that proper permissions are set.
+
+## Configuration
+
+Configuration will be handled by the system. The configuration file can be found in the installation directory.
+
+Users should modify the settings as needed. Click [here](https://example.com) for more information about configuration options.
+
+## Troubleshooting
+
+If there are issues, the following should be checked:
+
+- Log files should be examined
+- Network connectivity should be verified
+- Permissions should be validated
+
+Additional help can be found [here](https://example.com/help).
+
+## Code Example
+
+Here is some code:
+
+```
+# Install the package
+apt install package-name
+
+# Start the service  
+systemctl start service-name
+```
+
+The commands above will be executed by the system administrator.


### PR DESCRIPTION
Testing the automated documentation review system with intentional style issues:
- Passive voice usage ('should be installed by the user')
- Wordy phrases ('In order to', 'Due to the fact that')
- Non-descriptive link text ('Click here', 'here')
- Bullet points for sequential steps (should be numbered)
- Missing code syntax highlighting
- Third person instead of second person ('one should')

Expected Claude feedback:
- Convert passive to active voice
- Use 'you' instead of 'one'
- Replace wordy phrases with concise alternatives
- Use descriptive link text
- Number sequential procedures
- Add syntax highlighting to code blocks

🤖 Generated with [Claude Code](https://claude.ai/code)